### PR TITLE
dependabot - ignore minor csv updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       # ignore updates of minor importance
       - dependency-name: "git"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "csv"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
High frequency of  dependabot PRs is annoying and it seems to me that as this repo is not processing hostile input directly, immediate updates are of lesser priority

#79 for git seems to worked fine (see #96 - more important version bumps are still appearing apparently)